### PR TITLE
use the same db schema as dbconfig-common

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Import PHPMyAdmin schema
   mysql_db: name={{ phpmyadmin_control_database | default('phpmyadmin') }} state=import
-            target=/usr/share/doc/phpmyadmin/examples/create_tables.sql.gz
+            target=/usr/share/dbconfig-common/data/phpmyadmin/install/mysql
   when: phpmyadmin_database is defined and phpmyadmin_database.changed == True
 
 - name: Create PHPMyAdmin control user


### PR DESCRIPTION
The example schema differs from what dbconfig-common is using.